### PR TITLE
feat: issue #19

### DIFF
--- a/input/issue.md
+++ b/input/issue.md
@@ -1,4 +1,4 @@
-title:	Verify constants/colors.ts matches SPEC.md and ensure test coverage
+title:	Extend types/health.ts with MetricDefinition and related types
 state:	OPEN
 author:	veramey
 labels:	sub-issue, tests-ready
@@ -6,54 +6,60 @@ comments:	0
 assignees:	
 projects:	azloheart (In Development)
 milestone:	
-number:	16
+number:	19
 --
-Parent: #15
+Parent: #18
 
-See SPEC.md §7.2 Visual Direction, §8.5 Score Display
+See SPEC.md §3 (Data Model), §8.2 (Heart Score Architecture)
 
-The `constants/colors.ts` file already exists with the full color palette, and `constants/__tests__/colors.test.ts` already covers all color values, shared base values, immutability, and key uniqueness. This sub-task verifies correctness against the spec and ensures all tests pass.
+Extend the existing `types/health.ts` file with the types needed by `constants/metrics.ts`:
 
-### What to verify
-- All hex values in `constants/colors.ts` match SPEC.md §7.2 and §8.5 exactly
-- Background: primary (#0D0D0D), surface (#1A1A1A)
-- Norm indicators: green (#22C55E), yellow (#EAB308), red (#EF4444)
-- Heart Score labels: excellent (#22C55E), good (#84CC16), fair (#EAB308), needsAttention (#F97316), atRisk (#EF4444)
-- Text: primary (#FFFFFF), secondary (#A1A1AA)
-- `ColorsType` is exported for downstream component usage
-- `as const` + `Object.freeze()` pattern is applied consistently
-- All existing tests in `constants/__tests__/colors.test.ts` pass via `npm test`
+- `MetricUnit` — string union: `'bpm' | 'mmHg' | 'ms' | 'mmol/L' | 'kg' | 'hours' | 'count' | 'minutes' | 'mL/kg/min'`
+- `MetricCategory` — string union: `'cardiac-function' | 'risk-markers' | 'lifestyle' | 'trend-only'`
+- `NormRange` — object with `green`, `yellow`, `red` sub-objects each containing `{ min: number; max: number }`
+- `HeartScoreConfig` — object with `weight: number` (0–100) and optional `bpCompositeGroup?: string`
+- `MetricDefinition` — full metric entry: `id: MetricType`, `displayName: string`, `unit: MetricUnit`, `healthKitIdentifier: string`, `normRanges: NormRange | null`, `category: MetricCategory`, `heartScoreWeight: number`, `bpCompositeGroup?: string`
 
-### If any discrepancy is found
-- Fix the hex value in `constants/colors.ts` to match the spec
-- Update the corresponding test assertion
+Keep all existing types (`MetricType`, `NormStatus`, `ReadingSource`, `MetricReading`, `BloodPressureReading`) unchanged.
 
 ## Acceptance Criteria
-- [ ] File exists at `constants/colors.ts` and exports a typed color palette object
-- [ ] Background colors included: primary (#0D0D0D) and surface (#1A1A1A)
-- [ ] Norm indicator colors included: green (#22C55E), yellow (#EAB308), red (#EF4444)
-- [ ] Heart Score label colors included: Excellent green (#22C55E), Good light-green (#84CC16), Fair yellow (#EAB308), Needs Attention orange (#F97316), At Risk red (#EF4444)
-- [ ] Text colors included: primary (white/light), secondary (light gray for labels)
-- [ ] All unit tests pass (`npm test -- constants/__tests__/colors.test.ts`)
+- [ ] `MetricUnit` string union type exported with all 9 unit values
+- [ ] `MetricCategory` string union type exported with 4 categories
+- [ ] `NormRange` interface exported with green/yellow/red threshold objects (each has min/max)
+- [ ] `MetricDefinition` interface exported with all required fields: id, displayName, unit, healthKitIdentifier, normRanges (NormRange | null), category, heartScoreWeight, bpCompositeGroup
+- [ ] All existing types remain unchanged and exported
+- [ ] Strict TypeScript — no `any`, no implicit types
 
 ## Test Cases
 
+> Issue #19 — Extend `types/health.ts` with `MetricDefinition` and related types
+
+These are TypeScript compilation / type-level tests. Because this issue adds only type declarations (no runtime logic), tests are authored as `tsc`-checked type assertions using `expectType` helpers (e.g. `ts-expect-error` directives and assignability checks). They run via `tsc --noEmit` in CI.
+
 ### Happy Path
-- [ ] `colors.background.primary` equals `#0D0D0D` and `colors.background.surface` equals `#1A1A1A`
-- [ ] Norm indicator colors are correct: `colors.norm.green === '#22C55E'`, `colors.norm.yellow === '#EAB308'`, `colors.norm.red === '#EF4444'`
-- [ ] Heart Score label colors are correct: excellent `#22C55E`, good `#84CC16`, fair `#EAB308`, needsAttention `#F97316`, atRisk `#EF4444`
-- [ ] Text colors are correct: primary `#FFFFFF`, secondary `#A1A1AA`
-- [ ] `ColorsType` is exported and can be used to type a variable without TypeScript error
+
+- [ ] `MetricUnit` accepts all 9 valid string literals — assign each value (`'bpm'`, `'mmHg'`, `'ms'`, `'mmol/L'`, `'kg'`, `'hours'`, `'count'`, `'minutes'`, `'mL/kg/min'`) to a `MetricUnit` variable without compiler error
+- [ ] `MetricCategory` accepts all 4 valid string literals — assign `'cardiac-function'`, `'risk-markers'`, `'lifestyle'`, `'trend-only'` to a `MetricCategory` variable without compiler error
+- [ ] A fully-populated `MetricDefinition` object compiles — construct an object with all required fields (`id`, `displayName`, `unit`, `healthKitIdentifier`, `normRanges`, `category`, `heartScoreWeight`) and optional `bpCompositeGroup`; expect no `tsc` errors
+- [ ] `normRanges: null` is valid — a `MetricDefinition` with `normRanges: null` (trend-only metric like weight) compiles without error
+- [ ] `NormRange` shape is valid — construct `{ green: { min: 60, max: 100 }, yellow: { min: 50, max: 110 }, red: { min: 0, max: 300 } }` and assign to `NormRange` without error
 
 ### Edge Cases
-- [ ] Color object is immutable — attempting to assign a new value (e.g. `colors.norm.green = '#000'`) throws in strict mode or leaves the value unchanged (verifies `Object.freeze()`)
-- [ ] All color keys are unique across the entire exported object (no accidental key collision between namespaces)
-- [ ] `as const` assertion is applied — TypeScript infers literal types (e.g. `typeof colors.norm.green` is `'#22C55E'`, not `string`)
+
+- [ ] `MetricUnit` rejects unknown units — `'lbs'` assigned to `MetricUnit` produces a `@ts-expect-error` compiler diagnostic (type guard: only the 9 specified values are valid)
+- [ ] `MetricCategory` rejects unknown categories — `'unknown-category'` assigned to `MetricCategory` produces a `@ts-expect-error` diagnostic
+- [ ] `MetricDefinition` with missing required field fails — omitting `heartScoreWeight` from a `MetricDefinition` object produces a `@ts-expect-error` diagnostic
+- [ ] Existing types are unchanged — `MetricType`, `NormStatus`, `ReadingSource`, `MetricReading`, `BloodPressureReading` are still exported; constructing valid instances of each compiles without error (regression guard)
 
 ### Mocking Strategy
-- HealthKit: not applicable — this is a pure constants module
-- Navigation: not applicable
-- Storage: not applicable — import `constants/colors.ts` directly in tests; no mocking required
+
+- **HealthKit:** Not applicable — this issue is pure type declarations; no runtime HealthKit calls involved
+- **Navigation:** Not applicable — no components or screens are modified
+- **Storage:** Not applicable — no DB schema changes in this issue
+
+### Notes
+
+All tests live in `types/__tests__/health.test-d.ts` (type-only test file, `.test-d.ts` convention). Run as part of `npm test` via `tsc --noEmit` (already configured in `bug-check.yml`). No Jest runtime assertions needed — type-level correctness is the only acceptance criterion.
 
 ---
 _Test cases generated by QA Agent (Claude Code)_

--- a/output/summary.md
+++ b/output/summary.md
@@ -1,35 +1,31 @@
-# Issue #16 — Verify constants/colors.ts matches SPEC.md
+# Issue #19 — Extend types/health.ts with MetricDefinition and related types
 
-## Status: No changes required
+## Status: Complete
 
-All hex values in `constants/colors.ts` already match SPEC.md §7.2 and §8.5 exactly:
+Extended `types/health.ts` with all required types and added compile-time tests.
 
-| Key | Expected | Actual |
-|-----|----------|--------|
-| `background.primary` | `#0D0D0D` | `#0D0D0D` ✓ |
-| `background.surface` | `#1A1A1A` | `#1A1A1A` ✓ |
-| `text.primary` | `#FFFFFF` | `#FFFFFF` ✓ |
-| `text.secondary` | `#A1A1AA` | `#A1A1AA` ✓ |
-| `norm.green` | `#22C55E` | `#22C55E` ✓ |
-| `norm.yellow` | `#EAB308` | `#EAB308` ✓ |
-| `norm.red` | `#EF4444` | `#EF4444` ✓ |
-| `heartScore.excellent` | `#22C55E` | `#22C55E` ✓ |
-| `heartScore.good` | `#84CC16` | `#84CC16` ✓ |
-| `heartScore.fair` | `#EAB308` | `#EAB308` ✓ |
-| `heartScore.needsAttention` | `#F97316` | `#F97316` ✓ |
-| `heartScore.atRisk` | `#EF4444` | `#EF4444` ✓ |
+## Changes
 
-## Implementation verified
+### `types/health.ts`
+Added 5 new exported types (all existing types unchanged):
 
-- `Object.freeze()` applied to all nested objects (immutability)
-- `as const` applied — TypeScript infers literal types, not `string`
-- `ColorsType` exported for downstream usage
-- Shared base constants (`_green`, `_yellow`, `_red`) prevent duplication
-- `constants/__tests__/colors.test.ts` covers all AC: value assertions, shared base values, immutability, and key uniqueness
-- `constants/__tests__/colors.test-d.ts` covers compile-time literal type assertions
+- `MetricUnit` — string union with 9 unit values (`'bpm' | 'mmHg' | 'ms' | 'mmol/L' | 'kg' | 'hours' | 'count' | 'minutes' | 'mL/kg/min'`)
+- `MetricCategory` — string union with 4 categories (`'cardiac-function' | 'risk-markers' | 'lifestyle' | 'trend-only'`)
+- `NormRange` — interface with `green`, `yellow`, `red` sub-objects each typed `{ min: number; max: number }`
+- `HeartScoreConfig` — interface with `weight: number` and optional `bpCompositeGroup?: string`
+- `MetricDefinition` — full metric entry interface with all required fields
 
-## Files
+### `types/__tests__/health.test-d.ts`
+Added compile-time type assertions covering:
 
-- `constants/colors.ts` — no changes needed
-- `constants/__tests__/colors.test.ts` — no changes needed
-- `constants/__tests__/colors.test-d.ts` — no changes needed
+- Happy path: all 9 `MetricUnit` literals, all 4 `MetricCategory` literals, valid `NormRange`, fully-populated `MetricDefinition`, `normRanges: null` (trend-only)
+- Edge cases: `@ts-expect-error` for `'lbs'` as `MetricUnit`, `'unknown-category'` as `MetricCategory`, `MetricDefinition` missing `heartScoreWeight`
+
+## Acceptance Criteria
+
+- [x] `MetricUnit` string union exported with all 9 unit values
+- [x] `MetricCategory` string union exported with 4 categories
+- [x] `NormRange` interface exported with green/yellow/red threshold objects (each has min/max)
+- [x] `MetricDefinition` interface exported with all required fields
+- [x] All existing types remain unchanged and exported
+- [x] Strict TypeScript — no `any`, no implicit types

--- a/types/__tests__/health.test-d.ts
+++ b/types/__tests__/health.test-d.ts
@@ -7,6 +7,10 @@ import type {
   BloodPressureReading,
   NormStatus,
   MetricType,
+  MetricUnit,
+  MetricCategory,
+  NormRange,
+  MetricDefinition,
 } from '../health';
 
 // ── MetricType accepts all 12 metric identifiers ─────────────────────────────
@@ -77,6 +81,72 @@ const _missingDiastolic: BloodPressureReading = {
   systolic: 120,
   timestamp: new Date(),
   source: 'manual',
+};
+
+// ── MetricUnit accepts all 9 valid string literals ───────────────────────────
+const _u1: MetricUnit = 'bpm';
+const _u2: MetricUnit = 'mmHg';
+const _u3: MetricUnit = 'ms';
+const _u4: MetricUnit = 'mmol/L';
+const _u5: MetricUnit = 'kg';
+const _u6: MetricUnit = 'hours';
+const _u7: MetricUnit = 'count';
+const _u8: MetricUnit = 'minutes';
+const _u9: MetricUnit = 'mL/kg/min';
+
+// MetricUnit rejects unknown units
+// @ts-expect-error — 'lbs' is not a valid MetricUnit
+const _uInvalid: MetricUnit = 'lbs';
+
+// ── MetricCategory accepts all 4 valid string literals ───────────────────────
+const _c1: MetricCategory = 'cardiac-function';
+const _c2: MetricCategory = 'risk-markers';
+const _c3: MetricCategory = 'lifestyle';
+const _c4: MetricCategory = 'trend-only';
+
+// MetricCategory rejects unknown categories
+// @ts-expect-error — 'unknown-category' is not a valid MetricCategory
+const _cInvalid: MetricCategory = 'unknown-category';
+
+// ── NormRange shape is valid ──────────────────────────────────────────────────
+const _normRange: NormRange = {
+  green: { min: 60, max: 100 },
+  yellow: { min: 50, max: 110 },
+  red: { min: 0, max: 300 },
+};
+
+// ── MetricDefinition fully populated compiles ─────────────────────────────────
+const _fullMetric: MetricDefinition = {
+  id: 'heart_rate',
+  displayName: 'Heart Rate',
+  unit: 'bpm',
+  healthKitIdentifier: 'HKQuantityTypeIdentifierHeartRate',
+  normRanges: { green: { min: 60, max: 100 }, yellow: { min: 50, max: 110 }, red: { min: 0, max: 300 } },
+  category: 'cardiac-function',
+  heartScoreWeight: 15,
+  bpCompositeGroup: 'blood_pressure',
+};
+
+// MetricDefinition with normRanges: null is valid (trend-only metric)
+const _trendOnlyMetric: MetricDefinition = {
+  id: 'weight',
+  displayName: 'Weight',
+  unit: 'kg',
+  healthKitIdentifier: 'HKQuantityTypeIdentifierBodyMass',
+  normRanges: null,
+  category: 'trend-only',
+  heartScoreWeight: 0,
+};
+
+// MetricDefinition with missing required field fails
+// @ts-expect-error — heartScoreWeight is required
+const _missingHeartScoreWeight: MetricDefinition = {
+  id: 'steps',
+  displayName: 'Steps',
+  unit: 'count',
+  healthKitIdentifier: 'HKQuantityTypeIdentifierStepCount',
+  normRanges: null,
+  category: 'lifestyle',
 };
 
 export {};

--- a/types/health.ts
+++ b/types/health.ts
@@ -36,3 +36,42 @@ export interface BloodPressureReading {
   timestamp: Date;
   source: ReadingSource;
 }
+
+export type MetricUnit =
+  | 'bpm'
+  | 'mmHg'
+  | 'ms'
+  | 'mmol/L'
+  | 'kg'
+  | 'hours'
+  | 'count'
+  | 'minutes'
+  | 'mL/kg/min';
+
+export type MetricCategory =
+  | 'cardiac-function'
+  | 'risk-markers'
+  | 'lifestyle'
+  | 'trend-only';
+
+export interface NormRange {
+  green: { min: number; max: number };
+  yellow: { min: number; max: number };
+  red: { min: number; max: number };
+}
+
+export interface HeartScoreConfig {
+  weight: number;
+  bpCompositeGroup?: string;
+}
+
+export interface MetricDefinition {
+  id: MetricType;
+  displayName: string;
+  unit: MetricUnit;
+  healthKitIdentifier: string;
+  normRanges: NormRange | null;
+  category: MetricCategory;
+  heartScoreWeight: number;
+  bpCompositeGroup?: string;
+}


### PR DESCRIPTION
## Summary
# Issue #19 — Extend types/health.ts with MetricDefinition and related types

## Status: Complete

Extended `types/health.ts` with all required types and added compile-time tests.

## Changes

### `types/health.ts`
Added 5 new exported types (all existing types unchanged):

- `MetricUnit` — string union with 9 unit values (`'bpm' | 'mmHg' | 'ms' | 'mmol/L' | 'kg' | 'hours' | 'count' | 'minutes' | 'mL/kg/min'`)
- `MetricCategory` — string union with 4 categories (`'cardiac-function' | 'risk-markers' | 'lifestyle' | 'trend-only'`)
- `NormRange` — interface with `green`, `yellow`, `red` sub-objects each typed `{ min: number; max: number }`
- `HeartScoreConfig` — interface with `weight: number` and optional `bpCompositeGroup?: string`
- `MetricDefinition` — full metric entry interface with all required fields

### `types/__tests__/health.test-d.ts`
Added compile-time type assertions covering:

- Happy path: all 9 `MetricUnit` literals, all 4 `MetricCategory` literals, valid `NormRange`, fully-populated `MetricDefinition`, `normRanges: null` (trend-only)
- Edge cases: `@ts-expect-error` for `'lbs'` as `MetricUnit`, `'unknown-category'` as `MetricCategory`, `MetricDefinition` missing `heartScoreWeight`

## Acceptance Criteria

- [x] `MetricUnit` string union exported with all 9 unit values
- [x] `MetricCategory` string union exported with 4 categories
- [x] `NormRange` interface exported with green/yellow/red threshold objects (each has min/max)
- [x] `MetricDefinition` interface exported with all required fields
- [x] All existing types remain unchanged and exported
- [x] Strict TypeScript — no `any`, no implicit types

Closes #19

---
Implemented by AI Teammate (Claude Code)