### PR TITLE
feat: issue #26

### DIFF
--- a/constants/__tests__/theme.test.ts
+++ b/constants/__tests__/theme.test.ts
@@ -1,0 +1,182 @@
+import { Typography, Spacing, BorderRadius, MIN_TAP_TARGET } from '../theme';
+
+describe('Typography', () => {
+  it('fontFamily is System', () => {
+    expect(Typography.fontFamily).toBe('System');
+  });
+
+  describe('weights', () => {
+    it('regular equals 400', () => {
+      expect(Typography.weights.regular).toBe('400');
+    });
+
+    it('medium equals 500', () => {
+      expect(Typography.weights.medium).toBe('500');
+    });
+
+    it('semibold equals 600', () => {
+      expect(Typography.weights.semibold).toBe('600');
+    });
+
+    it('bold equals 700', () => {
+      expect(Typography.weights.bold).toBe('700');
+    });
+  });
+
+  describe('sizes', () => {
+    it('heading1 equals 34', () => {
+      expect(Typography.sizes.heading1).toBe(34);
+    });
+
+    it('heading2 equals 28', () => {
+      expect(Typography.sizes.heading2).toBe(28);
+    });
+
+    it('heading3 equals 22', () => {
+      expect(Typography.sizes.heading3).toBe(22);
+    });
+
+    it('body equals 16', () => {
+      expect(Typography.sizes.body).toBe(16);
+    });
+
+    it('bodySmall equals 14', () => {
+      expect(Typography.sizes.bodySmall).toBe(14);
+    });
+
+    it('caption equals 12', () => {
+      expect(Typography.sizes.caption).toBe(12);
+    });
+  });
+
+  describe('lineHeights', () => {
+    it('heading1 equals 46', () => {
+      expect(Typography.lineHeights.heading1).toBe(46);
+    });
+
+    it('heading2 equals 38', () => {
+      expect(Typography.lineHeights.heading2).toBe(38);
+    });
+
+    it('heading3 equals 30', () => {
+      expect(Typography.lineHeights.heading3).toBe(30);
+    });
+
+    it('body equals 22', () => {
+      expect(Typography.lineHeights.body).toBe(22);
+    });
+
+    it('bodySmall equals 20', () => {
+      expect(Typography.lineHeights.bodySmall).toBe(20);
+    });
+
+    it('caption equals 16', () => {
+      expect(Typography.lineHeights.caption).toBe(16);
+    });
+  });
+
+  describe('immutability', () => {
+    it('Typography is frozen', () => {
+      expect(Object.isFrozen(Typography)).toBe(true);
+    });
+
+    it('Typography.weights is frozen', () => {
+      expect(Object.isFrozen(Typography.weights)).toBe(true);
+    });
+
+    it('Typography.sizes is frozen', () => {
+      expect(Object.isFrozen(Typography.sizes)).toBe(true);
+    });
+
+    it('Typography.lineHeights is frozen', () => {
+      expect(Object.isFrozen(Typography.lineHeights)).toBe(true);
+    });
+
+    it('mutation of Typography.weights has no effect', () => {
+      const original = Typography.weights.regular;
+      // @ts-expect-error — intentionally testing immutability
+      expect(() => { Typography.weights.regular = '999'; }).toThrow();
+      expect(Typography.weights.regular).toBe(original);
+    });
+  });
+});
+
+describe('Spacing', () => {
+  it('xs equals 4', () => {
+    expect(Spacing.xs).toBe(4);
+  });
+
+  it('sm equals 8', () => {
+    expect(Spacing.sm).toBe(8);
+  });
+
+  it('md equals 12', () => {
+    expect(Spacing.md).toBe(12);
+  });
+
+  it('lg equals 16', () => {
+    expect(Spacing.lg).toBe(16);
+  });
+
+  it('xl equals 24', () => {
+    expect(Spacing.xl).toBe(24);
+  });
+
+  it('2xl equals 32', () => {
+    expect(Spacing['2xl']).toBe(32);
+  });
+
+  it('3xl equals 48', () => {
+    expect(Spacing['3xl']).toBe(48);
+  });
+
+  it('4xl equals 64', () => {
+    expect(Spacing['4xl']).toBe(64);
+  });
+
+  describe('immutability', () => {
+    it('Spacing is frozen', () => {
+      expect(Object.isFrozen(Spacing)).toBe(true);
+    });
+
+    it('mutation of Spacing has no effect', () => {
+      const original = Spacing.xs;
+      // @ts-expect-error — intentionally testing immutability
+      expect(() => { Spacing.xs = 999; }).toThrow();
+      expect(Spacing.xs).toBe(original);
+    });
+  });
+});
+
+describe('BorderRadius', () => {
+  it('small equals 8', () => {
+    expect(BorderRadius.small).toBe(8);
+  });
+
+  it('medium equals 12', () => {
+    expect(BorderRadius.medium).toBe(12);
+  });
+
+  it('large equals 16', () => {
+    expect(BorderRadius.large).toBe(16);
+  });
+
+  describe('immutability', () => {
+    it('BorderRadius is frozen', () => {
+      expect(Object.isFrozen(BorderRadius)).toBe(true);
+    });
+
+    it('mutation of BorderRadius has no effect', () => {
+      const original = BorderRadius.small;
+      // @ts-expect-error — intentionally testing immutability
+      expect(() => { BorderRadius.small = 999; }).toThrow();
+      expect(BorderRadius.small).toBe(original);
+    });
+  });
+});
+
+describe('MIN_TAP_TARGET', () => {
+  it('equals 44', () => {
+    expect(MIN_TAP_TARGET).toBe(44);
+  });
+});

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -1,0 +1,48 @@
+export const Typography = Object.freeze({
+  fontFamily: 'System' as const,
+  weights: Object.freeze({
+    regular: '400' as const,
+    medium: '500' as const,
+    semibold: '600' as const,
+    bold: '700' as const,
+  }),
+  sizes: Object.freeze({
+    heading1: 34 as const,
+    heading2: 28 as const,
+    heading3: 22 as const,
+    body: 16 as const,
+    bodySmall: 14 as const,
+    caption: 12 as const,
+  }),
+  lineHeights: Object.freeze({
+    heading1: 46 as const,
+    heading2: 38 as const,
+    heading3: 30 as const,
+    body: 22 as const,
+    bodySmall: 20 as const,
+    caption: 16 as const,
+  }),
+});
+
+export const Spacing = Object.freeze({
+  xs: 4 as const,
+  sm: 8 as const,
+  md: 12 as const,
+  lg: 16 as const,
+  xl: 24 as const,
+  '2xl': 32 as const,
+  '3xl': 48 as const,
+  '4xl': 64 as const,
+});
+
+export const BorderRadius = Object.freeze({
+  small: 8 as const,
+  medium: 12 as const,
+  large: 16 as const,
+});
+
+export const MIN_TAP_TARGET = 44 as const;
+
+export type TypographyType = typeof Typography;
+export type SpacingType = typeof Spacing;
+export type BorderRadiusType = typeof BorderRadius;

--- a/input/issue.md
+++ b/input/issue.md
@@ -1,65 +1,66 @@
-title:	Extend types/health.ts with MetricDefinition and related types
+title:	Create constants/theme.ts with typography, spacing, and border radius tokens
 state:	OPEN
 author:	veramey
 labels:	sub-issue, tests-ready
 comments:	0
 assignees:	
-projects:	azloheart (In Development)
+projects:	azloheart (Backlog)
 milestone:	
-number:	19
+number:	26
 --
-Parent: #18
+Parent: #25
 
-See SPEC.md §3 (Data Model), §8.2 (Heart Score Architecture)
+See SPEC.md §7.2 (Visual Direction), §7.4 (Design Principles), §5.3 (Project Structure)
 
-Extend the existing `types/health.ts` file with the types needed by `constants/metrics.ts`:
+Create `constants/theme.ts` following the exact same pattern as `constants/colors.ts` — `Object.freeze()` for runtime immutability + `as const` for compile-time literal types + exported type alias.
 
-- `MetricUnit` — string union: `'bpm' | 'mmHg' | 'ms' | 'mmol/L' | 'kg' | 'hours' | 'count' | 'minutes' | 'mL/kg/min'`
-- `MetricCategory` — string union: `'cardiac-function' | 'risk-markers' | 'lifestyle' | 'trend-only'`
-- `NormRange` — object with `green`, `yellow`, `red` sub-objects each containing `{ min: number; max: number }`
-- `HeartScoreConfig` — object with `weight: number` (0–100) and optional `bpCompositeGroup?: string`
-- `MetricDefinition` — full metric entry: `id: MetricType`, `displayName: string`, `unit: MetricUnit`, `healthKitIdentifier: string`, `normRanges: NormRange | null`, `category: MetricCategory`, `heartScoreWeight: number`, `bpCompositeGroup?: string`
+The file defines three token groups plus a layout constant:
 
-Keep all existing types (`MetricType`, `NormStatus`, `ReadingSource`, `MetricReading`, `BloodPressureReading`) unchanged.
+### Typography
+- `fontFamily`: `'System'` (resolves to SF Pro on iOS automatically)
+- `weights`: `{ regular: '400', medium: '500', semibold: '600', bold: '700' }` (string literals for React Native fontWeight)
+- `sizes`: `{ heading1: 34, heading2: 28, heading3: 22, body: 16, bodySmall: 14, caption: 12 }`
+- `lineHeights`: `{ heading1: 46, heading2: 38, heading3: 30, body: 22, bodySmall: 20, caption: 16 }` (~1.35x ratio)
+
+### Spacing (4-point base scale)
+- `{ xs: 4, sm: 8, md: 12, lg: 16, xl: 24, '2xl': 32, '3xl': 48, '4xl': 64 }`
+
+### BorderRadius
+- `{ small: 8, medium: 12, large: 16 }` — consistent with design-system.md 12–16px card corners
+
+### Layout
+- `MIN_TAP_TARGET = 44` (Apple HIG 44x44pt minimum)
+
+All nested objects must be individually `Object.freeze()`'d. Export type aliases: `TypographyType`, `SpacingType`, `BorderRadiusType`.
 
 ## Acceptance Criteria
-- [ ] `MetricUnit` string union type exported with all 9 unit values
-- [ ] `MetricCategory` string union type exported with 4 categories
-- [ ] `NormRange` interface exported with green/yellow/red threshold objects (each has min/max)
-- [ ] `MetricDefinition` interface exported with all required fields: id, displayName, unit, healthKitIdentifier, normRanges (NormRange | null), category, heartScoreWeight, bpCompositeGroup
-- [ ] All existing types remain unchanged and exported
-- [ ] Strict TypeScript — no `any`, no implicit types
+- [ ] `constants/theme.ts` exports a typed `Typography` object with SF Pro font family (`'System'`), weight variants (regular='400', medium='500', semibold='600', bold='700'), font sizes for heading1 (34), heading2 (28), heading3 (22), body (16), bodySmall (14), caption (12), and corresponding line heights
+- [ ] Exports a typed `Spacing` object: xs=4, sm=8, md=12, lg=16, xl=24, 2xl=32, 3xl=48, 4xl=64
+- [ ] Exports a typed `BorderRadius` object: small=8, medium=12, large=16
+- [ ] All exports use `as const` assertions for literal type safety
+- [ ] All objects are `Object.freeze()`'d (including nested objects) following `colors.ts` pattern
+- [ ] Exports `MIN_TAP_TARGET = 44` constant per Apple HIG
+- [ ] Type aliases exported for each token group
 
 ## Test Cases
 
-> Issue #19 — Extend `types/health.ts` with `MetricDefinition` and related types
-
-These are TypeScript compilation / type-level tests. Because this issue adds only type declarations (no runtime logic), tests are authored as `tsc`-checked type assertions using `expectType` helpers (e.g. `ts-expect-error` directives and assignability checks). They run via `tsc --noEmit` in CI.
-
 ### Happy Path
-
-- [ ] `MetricUnit` accepts all 9 valid string literals — assign each value (`'bpm'`, `'mmHg'`, `'ms'`, `'mmol/L'`, `'kg'`, `'hours'`, `'count'`, `'minutes'`, `'mL/kg/min'`) to a `MetricUnit` variable without compiler error
-- [ ] `MetricCategory` accepts all 4 valid string literals — assign `'cardiac-function'`, `'risk-markers'`, `'lifestyle'`, `'trend-only'` to a `MetricCategory` variable without compiler error
-- [ ] A fully-populated `MetricDefinition` object compiles — construct an object with all required fields (`id`, `displayName`, `unit`, `healthKitIdentifier`, `normRanges`, `category`, `heartScoreWeight`) and optional `bpCompositeGroup`; expect no `tsc` errors
-- [ ] `normRanges: null` is valid — a `MetricDefinition` with `normRanges: null` (trend-only metric like weight) compiles without error
-- [ ] `NormRange` shape is valid — construct `{ green: { min: 60, max: 100 }, yellow: { min: 50, max: 110 }, red: { min: 0, max: 300 } }` and assign to `NormRange` without error
+- [ ] `Typography` exported from `constants/theme.ts` has `fontFamily === 'System'`, weight `regular === '400'`, `medium === '500'`, `semibold === '600'`, `bold === '700'`
+- [ ] `Typography.sizes` contains exact values: `heading1=34`, `heading2=28`, `heading3=22`, `body=16`, `bodySmall=14`, `caption=12`
+- [ ] `Spacing` exported from `constants/theme.ts` contains exact values: `xs=4`, `sm=8`, `md=12`, `lg=16`, `xl=24`, `2xl=32`, `3xl=48`, `4xl=64`
+- [ ] `BorderRadius` exported from `constants/theme.ts` contains `small=8`, `medium=12`, `large=16`
+- [ ] `MIN_TAP_TARGET` is exported and equals `44`
 
 ### Edge Cases
-
-- [ ] `MetricUnit` rejects unknown units — `'lbs'` assigned to `MetricUnit` produces a `@ts-expect-error` compiler diagnostic (type guard: only the 9 specified values are valid)
-- [ ] `MetricCategory` rejects unknown categories — `'unknown-category'` assigned to `MetricCategory` produces a `@ts-expect-error` diagnostic
-- [ ] `MetricDefinition` with missing required field fails — omitting `heartScoreWeight` from a `MetricDefinition` object produces a `@ts-expect-error` diagnostic
-- [ ] Existing types are unchanged — `MetricType`, `NormStatus`, `ReadingSource`, `MetricReading`, `BloodPressureReading` are still exported; constructing valid instances of each compiles without error (regression guard)
+- [ ] All nested objects (`Typography.weights`, `Typography.sizes`, `Typography.lineHeights`, `Spacing`, `BorderRadius`) are frozen — `Object.isFrozen()` returns `true` for each
+- [ ] Attempting to mutate a token at runtime (e.g. `Spacing.xs = 999`) does not change the value (freeze enforcement in strict mode throws; non-strict silently ignores)
+- [ ] `Typography.lineHeights` values follow ~1.35x ratio: `heading1=46`, `heading2=38`, `heading3=30`, `body=22`, `bodySmall=20`, `caption=16`
 
 ### Mocking Strategy
-
-- **HealthKit:** Not applicable — this issue is pure type declarations; no runtime HealthKit calls involved
-- **Navigation:** Not applicable — no components or screens are modified
-- **Storage:** Not applicable — no DB schema changes in this issue
-
-### Notes
-
-All tests live in `types/__tests__/health.test-d.ts` (type-only test file, `.test-d.ts` convention). Run as part of `npm test` via `tsc --noEmit` (already configured in `bug-check.yml`). No Jest runtime assertions needed — type-level correctness is the only acceptance criterion.
+- HealthKit: not applicable — this is a pure constants file with no HealthKit dependency
+- Navigation: not applicable — no navigation dependency
+- Storage: not applicable — no DB dependency
+- TypeScript: run `tsc --noEmit` to verify type aliases (`TypographyType`, `SpacingType`, `BorderRadiusType`) resolve correctly and that `as const` assertions produce literal types (e.g. `Spacing.xs` is type `4`, not `number`)
 
 ---
 _Test cases generated by QA Agent (Claude Code)_

--- a/output/summary.md
+++ b/output/summary.md
@@ -1,31 +1,30 @@
-# Issue #19 — Extend types/health.ts with MetricDefinition and related types
+# Issue #26 — constants/theme.ts
 
 ## Status: Complete
 
-Extended `types/health.ts` with all required types and added compile-time tests.
+Created `constants/theme.ts` with typography, spacing, and border radius design tokens, following the same `Object.freeze()` + `as const` pattern as `constants/colors.ts`.
 
-## Changes
+## Files created
 
-### `types/health.ts`
-Added 5 new exported types (all existing types unchanged):
+- `constants/theme.ts` — exports `Typography`, `Spacing`, `BorderRadius`, and `MIN_TAP_TARGET`
+- `constants/__tests__/theme.test.ts` — Jest tests covering all values, immutability, and mutation enforcement
 
-- `MetricUnit` — string union with 9 unit values (`'bpm' | 'mmHg' | 'ms' | 'mmol/L' | 'kg' | 'hours' | 'count' | 'minutes' | 'mL/kg/min'`)
-- `MetricCategory` — string union with 4 categories (`'cardiac-function' | 'risk-markers' | 'lifestyle' | 'trend-only'`)
-- `NormRange` — interface with `green`, `yellow`, `red` sub-objects each typed `{ min: number; max: number }`
-- `HeartScoreConfig` — interface with `weight: number` and optional `bpCompositeGroup?: string`
-- `MetricDefinition` — full metric entry interface with all required fields
+## Exports
 
-### `types/__tests__/health.test-d.ts`
-Added compile-time type assertions covering:
+- `Typography` — `fontFamily: 'System'`, `weights` (regular/medium/semibold/bold), `sizes` (heading1–caption), `lineHeights`
+- `Spacing` — 4-point scale: xs=4, sm=8, md=12, lg=16, xl=24, 2xl=32, 3xl=48, 4xl=64
+- `BorderRadius` — small=8, medium=12, large=16
+- `MIN_TAP_TARGET = 44`
+- Type aliases: `TypographyType`, `SpacingType`, `BorderRadiusType`
 
-- Happy path: all 9 `MetricUnit` literals, all 4 `MetricCategory` literals, valid `NormRange`, fully-populated `MetricDefinition`, `normRanges: null` (trend-only)
-- Edge cases: `@ts-expect-error` for `'lbs'` as `MetricUnit`, `'unknown-category'` as `MetricCategory`, `MetricDefinition` missing `heartScoreWeight`
+All nested objects are individually `Object.freeze()`'d. All values use `as const` for literal type inference.
 
 ## Acceptance Criteria
 
-- [x] `MetricUnit` string union exported with all 9 unit values
-- [x] `MetricCategory` string union exported with 4 categories
-- [x] `NormRange` interface exported with green/yellow/red threshold objects (each has min/max)
-- [x] `MetricDefinition` interface exported with all required fields
-- [x] All existing types remain unchanged and exported
-- [x] Strict TypeScript — no `any`, no implicit types
+- [x] `Typography` exported with `fontFamily: 'System'`, all weight variants, sizes (heading1=34 … caption=12), and line heights
+- [x] `Spacing` exported with xs=4, sm=8, md=12, lg=16, xl=24, 2xl=32, 3xl=48, 4xl=64
+- [x] `BorderRadius` exported with small=8, medium=12, large=16
+- [x] All exports use `as const` for literal type safety
+- [x] All objects (including nested) are `Object.freeze()`'d
+- [x] `MIN_TAP_TARGET = 44` exported
+- [x] Type aliases `TypographyType`, `SpacingType`, `BorderRadiusType` exported


### PR DESCRIPTION
## Summary
# Issue #26 — constants/theme.ts

## Status: Complete

Created `constants/theme.ts` with typography, spacing, and border radius design tokens, following the same `Object.freeze()` + `as const` pattern as `constants/colors.ts`.

## Files created

- `constants/theme.ts` — exports `Typography`, `Spacing`, `BorderRadius`, and `MIN_TAP_TARGET`
- `constants/__tests__/theme.test.ts` — Jest tests covering all values, immutability, and mutation enforcement

## Exports

- `Typography` — `fontFamily: 'System'`, `weights` (regular/medium/semibold/bold), `sizes` (heading1–caption), `lineHeights`
- `Spacing` — 4-point scale: xs=4, sm=8, md=12, lg=16, xl=24, 2xl=32, 3xl=48, 4xl=64
- `BorderRadius` — small=8, medium=12, large=16
- `MIN_TAP_TARGET = 44`
- Type aliases: `TypographyType`, `SpacingType`, `BorderRadiusType`

All nested objects are individually `Object.freeze()`'d. All values use `as const` for literal type inference.

## Acceptance Criteria

- [x] `Typography` exported with `fontFamily: 'System'`, all weight variants, sizes (heading1=34 … caption=12), and line heights
- [x] `Spacing` exported with xs=4, sm=8, md=12, lg=16, xl=24, 2xl=32, 3xl=48, 4xl=64
- [x] `BorderRadius` exported with small=8, medium=12, large=16
- [x] All exports use `as const` for literal type safety
- [x] All objects (including nested) are `Object.freeze()`'d
- [x] `MIN_TAP_TARGET = 44` exported
- [x] Type aliases `TypographyType`, `SpacingType`, `BorderRadiusType` exported

Closes #26

---
Implemented by AI Teammate (Claude Code)