### PR TITLE
feat: issue #30

### DIFF
--- a/constants/__tests__/metrics.test.ts
+++ b/constants/__tests__/metrics.test.ts
@@ -1,0 +1,150 @@
+import { METRICS } from '../metrics';
+import { METRIC_TYPES } from '../../types/health';
+import type { MetricType } from '../../types/health';
+
+describe('METRICS', () => {
+  describe('happy path', () => {
+    it('has exactly 12 keys matching all MetricType values', () => {
+      const keys = Object.keys(METRICS) as MetricType[];
+      expect(keys).toHaveLength(12);
+      expect(keys.sort()).toEqual([...METRIC_TYPES].sort());
+    });
+
+    it('heartScoreWeight values across all entries sum to exactly 100', () => {
+      const total = Object.values(METRICS).reduce(
+        (sum, def) => sum + def.heartScoreWeight,
+        0,
+      );
+      expect(total).toBe(100);
+    });
+
+    it('each entry with non-null normRanges has min <= max for all three thresholds', () => {
+      for (const [id, def] of Object.entries(METRICS)) {
+        if (def.normRanges === null) continue;
+        const { green, yellow, red } = def.normRanges;
+        expect(green.min).toBeLessThanOrEqual(green.max);
+        expect(yellow.min).toBeLessThanOrEqual(yellow.max);
+        expect(red.min).toBeLessThanOrEqual(red.max);
+        // ensure all three keys exist
+        expect(green).toBeDefined();
+        expect(yellow).toBeDefined();
+        expect(red).toBeDefined();
+        void id; // suppress unused warning
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('weight has normRanges: null and heartScoreWeight: 0', () => {
+      expect(METRICS.weight.normRanges).toBeNull();
+      expect(METRICS.weight.heartScoreWeight).toBe(0);
+    });
+
+    it('walking_hr_avg has normRanges: null and heartScoreWeight: 0', () => {
+      expect(METRICS.walking_hr_avg.normRanges).toBeNull();
+      expect(METRICS.walking_hr_avg.heartScoreWeight).toBe(0);
+    });
+
+    it('vo2_max has normRanges: null', () => {
+      expect(METRICS.vo2_max.normRanges).toBeNull();
+    });
+
+    it('blood_pressure_systolic has bpCompositeGroup: "blood_pressure"', () => {
+      expect(METRICS.blood_pressure_systolic.bpCompositeGroup).toBe('blood_pressure');
+    });
+
+    it('blood_pressure_diastolic has bpCompositeGroup: "blood_pressure"', () => {
+      expect(METRICS.blood_pressure_diastolic.bpCompositeGroup).toBe('blood_pressure');
+    });
+
+    it('all other entries have bpCompositeGroup: undefined', () => {
+      const nonBpMetrics = (Object.keys(METRICS) as MetricType[]).filter(
+        (k) => k !== 'blood_pressure_systolic' && k !== 'blood_pressure_diastolic',
+      );
+      for (const key of nonBpMetrics) {
+        expect(METRICS[key].bpCompositeGroup).toBeUndefined();
+      }
+    });
+
+    it('yellow ranges are contiguous with green ranges (no gaps, no overlaps)', () => {
+      for (const [id, def] of Object.entries(METRICS)) {
+        if (def.normRanges === null) continue;
+        const { green, yellow } = def.normRanges;
+        const contiguous =
+          yellow.min === green.max || yellow.max === green.min;
+        expect({ id, contiguous }).toMatchObject({ id, contiguous: true });
+      }
+    });
+  });
+
+  describe('immutability', () => {
+    it('METRICS object is frozen', () => {
+      expect(Object.isFrozen(METRICS)).toBe(true);
+    });
+
+    it('each metric definition is frozen', () => {
+      for (const def of Object.values(METRICS)) {
+        expect(Object.isFrozen(def)).toBe(true);
+      }
+    });
+
+    it('normRanges objects are frozen when not null', () => {
+      for (const def of Object.values(METRICS)) {
+        if (def.normRanges !== null) {
+          expect(Object.isFrozen(def.normRanges)).toBe(true);
+        }
+      }
+    });
+  });
+
+  describe('individual metric definitions', () => {
+    it('heart_rate has id matching key, bpm unit, cardiac-function category', () => {
+      expect(METRICS.heart_rate.id).toBe('heart_rate');
+      expect(METRICS.heart_rate.unit).toBe('bpm');
+      expect(METRICS.heart_rate.category).toBe('cardiac-function');
+      expect(METRICS.heart_rate.heartScoreWeight).toBe(0);
+    });
+
+    it('resting_heart_rate has heartScoreWeight 15', () => {
+      expect(METRICS.resting_heart_rate.heartScoreWeight).toBe(15);
+      expect(METRICS.resting_heart_rate.category).toBe('cardiac-function');
+    });
+
+    it('hrv has heartScoreWeight 15 and ms unit', () => {
+      expect(METRICS.hrv.heartScoreWeight).toBe(15);
+      expect(METRICS.hrv.unit).toBe('ms');
+    });
+
+    it('vo2_max has heartScoreWeight 10 and mL/kg/min unit', () => {
+      expect(METRICS.vo2_max.heartScoreWeight).toBe(10);
+      expect(METRICS.vo2_max.unit).toBe('mL/kg/min');
+    });
+
+    it('blood_glucose has heartScoreWeight 15 and mmol/L unit', () => {
+      expect(METRICS.blood_glucose.heartScoreWeight).toBe(15);
+      expect(METRICS.blood_glucose.unit).toBe('mmol/L');
+    });
+
+    it('sleep has heartScoreWeight 10 and hours unit', () => {
+      expect(METRICS.sleep.heartScoreWeight).toBe(10);
+      expect(METRICS.sleep.unit).toBe('hours');
+      expect(METRICS.sleep.category).toBe('lifestyle');
+    });
+
+    it('steps has heartScoreWeight 8 and count unit', () => {
+      expect(METRICS.steps.heartScoreWeight).toBe(8);
+      expect(METRICS.steps.unit).toBe('count');
+    });
+
+    it('workouts has heartScoreWeight 7 and minutes unit', () => {
+      expect(METRICS.workouts.heartScoreWeight).toBe(7);
+      expect(METRICS.workouts.unit).toBe('minutes');
+    });
+
+    it('every entry id matches its key', () => {
+      for (const [key, def] of Object.entries(METRICS)) {
+        expect(def.id).toBe(key);
+      }
+    });
+  });
+});

--- a/constants/metrics.ts
+++ b/constants/metrics.ts
@@ -1,0 +1,161 @@
+import type { MetricDefinition, MetricType } from '../types/health';
+
+export const METRICS: Record<MetricType, MetricDefinition> = Object.freeze({
+  heart_rate: Object.freeze({
+    id: 'heart_rate' as const,
+    displayName: 'Heart Rate',
+    unit: 'bpm' as const,
+    healthKitIdentifier: 'HKQuantityTypeIdentifierHeartRate',
+    normRanges: Object.freeze({
+      green: Object.freeze({ min: 60, max: 100 }),
+      yellow: Object.freeze({ min: 100, max: 120 }),
+      red: Object.freeze({ min: 120, max: 300 }),
+    }),
+    category: 'cardiac-function' as const,
+    heartScoreWeight: 0,
+  }),
+
+  resting_heart_rate: Object.freeze({
+    id: 'resting_heart_rate' as const,
+    displayName: 'Resting Heart Rate',
+    unit: 'bpm' as const,
+    healthKitIdentifier: 'HKQuantityTypeIdentifierRestingHeartRate',
+    normRanges: Object.freeze({
+      green: Object.freeze({ min: 40, max: 80 }),
+      yellow: Object.freeze({ min: 80, max: 92 }),
+      red: Object.freeze({ min: 92, max: 300 }),
+    }),
+    category: 'cardiac-function' as const,
+    heartScoreWeight: 15,
+  }),
+
+  blood_pressure_systolic: Object.freeze({
+    id: 'blood_pressure_systolic' as const,
+    displayName: 'Systolic Blood Pressure',
+    unit: 'mmHg' as const,
+    healthKitIdentifier: 'HKQuantityTypeIdentifierBloodPressureSystolic',
+    normRanges: Object.freeze({
+      green: Object.freeze({ min: 90, max: 120 }),
+      yellow: Object.freeze({ min: 120, max: 140 }),
+      red: Object.freeze({ min: 140, max: 300 }),
+    }),
+    category: 'risk-markers' as const,
+    heartScoreWeight: 10,
+    bpCompositeGroup: 'blood_pressure' as const,
+  }),
+
+  blood_pressure_diastolic: Object.freeze({
+    id: 'blood_pressure_diastolic' as const,
+    displayName: 'Diastolic Blood Pressure',
+    unit: 'mmHg' as const,
+    healthKitIdentifier: 'HKQuantityTypeIdentifierBloodPressureDiastolic',
+    normRanges: Object.freeze({
+      green: Object.freeze({ min: 60, max: 80 }),
+      yellow: Object.freeze({ min: 80, max: 90 }),
+      red: Object.freeze({ min: 90, max: 200 }),
+    }),
+    category: 'risk-markers' as const,
+    heartScoreWeight: 10,
+    bpCompositeGroup: 'blood_pressure' as const,
+  }),
+
+  hrv: Object.freeze({
+    id: 'hrv' as const,
+    displayName: 'HRV (SDNN)',
+    unit: 'ms' as const,
+    healthKitIdentifier: 'HKQuantityTypeIdentifierHeartRateVariabilitySDNN',
+    normRanges: Object.freeze({
+      red: Object.freeze({ min: 0, max: 15 }),
+      yellow: Object.freeze({ min: 15, max: 20 }),
+      green: Object.freeze({ min: 20, max: 500 }),
+    }),
+    category: 'cardiac-function' as const,
+    heartScoreWeight: 15,
+  }),
+
+  blood_glucose: Object.freeze({
+    id: 'blood_glucose' as const,
+    displayName: 'Blood Glucose',
+    unit: 'mmol/L' as const,
+    healthKitIdentifier: 'HKQuantityTypeIdentifierBloodGlucose',
+    normRanges: Object.freeze({
+      green: Object.freeze({ min: 3.9, max: 5.6 }),
+      yellow: Object.freeze({ min: 5.6, max: 7.0 }),
+      red: Object.freeze({ min: 7.0, max: 30 }),
+    }),
+    category: 'risk-markers' as const,
+    heartScoreWeight: 15,
+  }),
+
+  weight: Object.freeze({
+    id: 'weight' as const,
+    displayName: 'Weight',
+    unit: 'kg' as const,
+    healthKitIdentifier: 'HKQuantityTypeIdentifierBodyMass',
+    normRanges: null,
+    category: 'trend-only' as const,
+    heartScoreWeight: 0,
+  }),
+
+  sleep: Object.freeze({
+    id: 'sleep' as const,
+    displayName: 'Sleep',
+    unit: 'hours' as const,
+    healthKitIdentifier: 'HKCategoryTypeIdentifierSleepAnalysis',
+    normRanges: Object.freeze({
+      red: Object.freeze({ min: 0, max: 5 }),
+      yellow: Object.freeze({ min: 5, max: 7 }),
+      green: Object.freeze({ min: 7, max: 24 }),
+    }),
+    category: 'lifestyle' as const,
+    heartScoreWeight: 10,
+  }),
+
+  steps: Object.freeze({
+    id: 'steps' as const,
+    displayName: 'Daily Steps',
+    unit: 'count' as const,
+    healthKitIdentifier: 'HKQuantityTypeIdentifierStepCount',
+    normRanges: Object.freeze({
+      red: Object.freeze({ min: 0, max: 4000 }),
+      yellow: Object.freeze({ min: 4000, max: 7000 }),
+      green: Object.freeze({ min: 7000, max: 100000 }),
+    }),
+    category: 'lifestyle' as const,
+    heartScoreWeight: 8,
+  }),
+
+  workouts: Object.freeze({
+    id: 'workouts' as const,
+    displayName: 'Weekly Exercise',
+    unit: 'minutes' as const,
+    healthKitIdentifier: 'HKWorkoutTypeIdentifier',
+    normRanges: Object.freeze({
+      red: Object.freeze({ min: 0, max: 75 }),
+      yellow: Object.freeze({ min: 75, max: 150 }),
+      green: Object.freeze({ min: 150, max: 10000 }),
+    }),
+    category: 'lifestyle' as const,
+    heartScoreWeight: 7,
+  }),
+
+  walking_hr_avg: Object.freeze({
+    id: 'walking_hr_avg' as const,
+    displayName: 'Walking Heart Rate Avg',
+    unit: 'bpm' as const,
+    healthKitIdentifier: 'HKQuantityTypeIdentifierWalkingHeartRateAverage',
+    normRanges: null,
+    category: 'trend-only' as const,
+    heartScoreWeight: 0,
+  }),
+
+  vo2_max: Object.freeze({
+    id: 'vo2_max' as const,
+    displayName: 'VO2 Max',
+    unit: 'mL/kg/min' as const,
+    healthKitIdentifier: 'HKQuantityTypeIdentifierVO2Max',
+    normRanges: null,
+    category: 'cardiac-function' as const,
+    heartScoreWeight: 10,
+  }),
+});

--- a/input/issue.md
+++ b/input/issue.md
@@ -1,4 +1,4 @@
-title:	Add runtime and compile-time tests for constants/theme.ts
+title:	Create constants/metrics.ts with all 12 metric definitions
 state:	OPEN
 author:	veramey
 labels:	sub-issue, tests-ready
@@ -6,67 +6,54 @@ comments:	0
 assignees:	
 projects:	azloheart (Backlog)
 milestone:	
-number:	27
+number:	30
 --
-Parent: #25
+Parent: #18
 
-See SPEC.md §7.2 (Visual Direction)
+## Description
 
-Depends on: `constants/theme.ts` from previous sub-task.
+`constants/metrics.ts` was never created despite sub-issue #20 being closed. This file must be created to satisfy AC1–AC4 of the parent issue.
 
-Create two test files following the pattern established by `constants/__tests__/colors.test.ts` and `constants/__tests__/colors.test-d.ts`.
+Create `constants/metrics.ts` exporting a `METRICS: Record<MetricType, MetricDefinition>` constant with all 12 entries (11 metrics, BP split into systolic + diastolic). Follow the existing pattern from `constants/colors.ts`: use `Object.freeze()` and `as const` for immutability.
 
-### Runtime tests (`constants/__tests__/theme.test.ts`)
-- All Typography values match expected: fontFamily='System', sizes (34/28/22/16/14/12), lineHeights (46/38/30/22/20/16), weights ('400'/'500'/'600'/'700')
-- All Spacing values match expected: xs=4, sm=8, md=12, lg=16, xl=24, 2xl=32, 3xl=48, 4xl=64
-- All BorderRadius values match expected: small=8, medium=12, large=16
-- `Object.isFrozen()` assertions on all exported objects AND all nested objects
-- Mutation throws in strict mode (matching colors.test.ts pattern)
-- Spacing values are strictly ascending (each value > previous)
-- Every line height is greater than its corresponding font size
-- Font weights are valid React Native fontWeight strings
-- `MIN_TAP_TARGET` equals 44
-- No duplicate keys within groups
+For each metric entry include:
+- `id` — matches the `MetricType` key
+- `displayName` — human-readable name
+- `unit` — typed `MetricUnit` value
+- `healthKitIdentifier` — react-native-health identifier string
+- `normRanges` — green/yellow/red thresholds from SPEC.md §3 and §8.3, or `null` for trend-only metrics (weight, vo2_max, walking_hr_avg)
+- `category` — one of `cardiac-function`, `risk-markers`, `lifestyle`, `trend-only`
+- `heartScoreWeight` — resting HR 15, HRV 15, VO2 max 10, BP systolic 10, BP diastolic 10, glucose 15, sleep 10, steps 8, workouts 7; 0 for heart_rate, weight, walking_hr_avg
+- `bpCompositeGroup` — `'blood_pressure'` for systolic and diastolic entries, undefined for others
 
-### Compile-time type tests (`constants/__tests__/theme.test-d.ts`)
-- Literal type preservation: `Typography.sizes.body` is type `16` not `number`
-- `Spacing.md` is type `12` not `number`
-- `BorderRadius.medium` is type `12` not `number`
-- `@ts-expect-error` for assigning wrong literal values to verify const narrowing
+All types are already available in `types/health.ts`.
 
 ## Acceptance Criteria
-- [ ] `constants/__tests__/theme.test.ts` exists with runtime Jest tests covering all token values, immutability, scale progression, and line height invariants
-- [ ] `constants/__tests__/theme.test-d.ts` exists with compile-time type tests verifying literal type preservation via `@ts-expect-error`
-- [ ] All tests pass with `npm test`
-- [ ] Test structure follows the same describe/it pattern as `colors.test.ts`
+- [ ] `constants/metrics.ts` file exists and exports `METRICS: Record<MetricType, MetricDefinition>`
+- [ ] METRICS record has exactly 12 entries — one per MetricType
+- [ ] Heart Score weights sum to 100 across the 8 scored metrics
+- [ ] Trend-only metrics (weight, vo2_max, walking_hr_avg) have `normRanges: null` and `heartScoreWeight: 0`
+- [ ] BP systolic and diastolic both have `bpCompositeGroup: 'blood_pressure'` set
+- [ ] All normRanges (when not null) have green, yellow, red with `min <= max`
+- [ ] Yellow ranges border green ranges (no gaps, no overlaps)
+- [ ] File uses `Object.freeze()` and `as const` for immutability
 
 ## Test Cases
 
 ### Happy Path
-
-- [ ] `Typography` values match expected: `fontFamily` is `'System'`, sizes are `{ largeTitle: 34, title: 28, title2: 22, body: 16, subheadline: 14, caption: 12 }`, lineHeights are `{ largeTitle: 46, title: 38, title2: 30, body: 22, subheadline: 20, caption: 16 }`, weights are `{ regular: '400', medium: '500', semibold: '600', bold: '700' }`
-- [ ] `Spacing` values match expected: `{ xs: 4, sm: 8, md: 12, lg: 16, xl: 24, '2xl': 32, '3xl': 48, '4xl': 64 }`
-- [ ] `BorderRadius` values match expected: `{ small: 8, medium: 12, large: 16 }`
-- [ ] `MIN_TAP_TARGET` equals `44`
-- [ ] All exported objects and their nested objects are frozen (`Object.isFrozen()` returns `true` for `Typography`, `Typography.sizes`, `Typography.lineHeights`, `Typography.weights`, `Spacing`, `BorderRadius`)
+- [ ] `METRICS` export has exactly 12 keys matching all `MetricType` values
+- [ ] Heart Score weights (`heartScoreWeight`) across all entries sum to exactly 100
+- [ ] Each entry with non-null `normRanges` has all three thresholds (green, yellow, red) where `min <= max`
 
 ### Edge Cases
-
-- [ ] Mutation of a frozen nested object (e.g. `Typography.sizes.body = 99`) throws a `TypeError` in strict mode, matching the `colors.test.ts` pattern
-- [ ] Spacing values are strictly ascending: each value in `[xs, sm, md, lg, xl, '2xl', '3xl', '4xl']` is greater than the previous
-- [ ] Every `Typography.lineHeight` is strictly greater than its corresponding `Typography.sizes` value (e.g. `lineHeights.body (22) > sizes.body (16)`)
-- [ ] Each `Typography.weights` value is a valid React Native `fontWeight` string (one of `'100'`–`'900'`, `'normal'`, `'bold'`)
-- [ ] No duplicate keys within each group (`Typography.sizes`, `Typography.lineHeights`, `Typography.weights`, `Spacing`, `BorderRadius`)
+- [ ] Trend-only metrics (`weight`, `vo2_max`, `walking_hr_avg`) have `normRanges: null` and `heartScoreWeight: 0`
+- [ ] `bp_systolic` and `bp_diastolic` both have `bpCompositeGroup: 'blood_pressure'`; all other entries have `bpCompositeGroup: undefined`
+- [ ] Yellow ranges are contiguous with green ranges — no gaps and no overlaps between yellow.max and green.min (or green.max and yellow.min) for every metric with normRanges
 
 ### Mocking Strategy
-
-- HealthKit: not applicable — this is a constants-only module with no HealthKit dependency
-- Navigation: not applicable — no expo-router usage
-- Storage: not applicable — no local DB usage; import `constants/theme` directly in tests
-
----
-
-> Note: the compile-time test file (`theme.test-d.ts`) requires no runtime mocking. It relies solely on TypeScript's `tsc --noEmit` to verify that `as const` preserves literal types (`Typography.sizes.body` is `16`, not `number`; `Spacing.md` is `12`, not `number`; `BorderRadius.medium` is `12`, not `number`) and that `@ts-expect-error` correctly rejects wrong literal assignments.
+- HealthKit: none needed — this is a pure constants file with no runtime HealthKit calls
+- Navigation: none needed
+- Storage: none needed — import `METRICS` directly and assert on its shape
 
 ---
 _Test cases generated by QA Agent (Claude Code)_

--- a/output/summary.md
+++ b/output/summary.md
@@ -1,33 +1,53 @@
-# Issue #27 — Theme Constants Tests
+# Issue #30 — Create constants/metrics.ts with all 12 metric definitions
 
 ## Status: Complete
 
-Created `constants/theme.ts` and both test files following the established colors pattern.
+Created `constants/metrics.ts` exporting `METRICS: Record<MetricType, MetricDefinition>` with all 12 entries, plus tests.
 
 ## Changes
 
-### `constants/theme.ts`
-Theme constant module exporting `Typography`, `Spacing`, `BorderRadius`, and `MIN_TAP_TARGET`. All objects are deeply frozen with `as const` literal types.
+### `constants/metrics.ts`
 
-### `constants/__tests__/theme.test.ts`
-Runtime Jest tests covering:
-- All token values (Typography fontFamily, sizes, lineHeights, weights; Spacing; BorderRadius; MIN_TAP_TARGET)
-- `Object.isFrozen()` on all exported objects and nested objects
-- Mutation throws `TypeError` in strict mode
-- Spacing values are strictly ascending
-- Every line height is greater than its corresponding font size
-- Font weights are valid React Native `fontWeight` strings
-- No duplicate keys within any group
+Exports `METRICS` — a deeply frozen `Record<MetricType, MetricDefinition>` with all 12 metric entries:
 
-### `constants/__tests__/theme.test-d.ts`
-Compile-time type tests verified by `tsc --noEmit`:
-- `Typography.sizes.body` is type `16`, not `number`
-- `Spacing.md` is type `12`, not `number`
-- `BorderRadius.medium` is type `12`, not `number`
-- `@ts-expect-error` confirms wrong literal assignments are rejected
+| Metric | Category | Weight | Norm Ranges |
+|---|---|---|---|
+| heart_rate | cardiac-function | 0 | green 60–100, yellow 100–120, red 120–300 bpm |
+| resting_heart_rate | cardiac-function | 15 | green 40–80, yellow 80–92, red 92–300 bpm |
+| blood_pressure_systolic | risk-markers | 10 | green 90–120, yellow 120–140, red 140–300 mmHg |
+| blood_pressure_diastolic | risk-markers | 10 | green 60–80, yellow 80–90, red 90–200 mmHg |
+| hrv | cardiac-function | 15 | red 0–15, yellow 15–20, green 20–500 ms |
+| blood_glucose | risk-markers | 15 | green 3.9–5.6, yellow 5.6–7.0, red 7.0–30 mmol/L |
+| weight | trend-only | 0 | null |
+| sleep | lifestyle | 10 | red 0–5, yellow 5–7, green 7–24 hours |
+| steps | lifestyle | 8 | red 0–4000, yellow 4000–7000, green 7000–100000 count |
+| workouts | lifestyle | 7 | red 0–75, yellow 75–150, green 150–10000 minutes |
+| walking_hr_avg | trend-only | 0 | null |
+| vo2_max | cardiac-function | 10 | null |
+
+**Heart score weights sum: 100** (0+15+10+10+15+15+0+10+8+7+0+10)
+
+Both `blood_pressure_systolic` and `blood_pressure_diastolic` have `bpCompositeGroup: 'blood_pressure'`. All three trend-only metrics have `normRanges: null`. Yellow ranges are contiguous with green on every metric (no gaps, no overlaps). The outer object and each nested definition/normRange object is `Object.freeze()`d.
+
+### `constants/__tests__/metrics.test.ts`
+
+Jest tests covering all acceptance criteria:
+- 12 keys matching all `MetricType` values
+- Weights sum to exactly 100
+- Non-null normRanges have `min <= max` for all three thresholds
+- `weight` and `walking_hr_avg` have `normRanges: null` and `heartScoreWeight: 0`
+- `vo2_max` has `normRanges: null`
+- Both BP entries have `bpCompositeGroup: 'blood_pressure'`; all others have `undefined`
+- Yellow ranges contiguous with green (no gaps/overlaps)
+- `METRICS`, each definition, and each normRanges are frozen
 
 ## Acceptance Criteria
 
-- [x] `constants/__tests__/theme.test.ts` exists with runtime Jest tests covering all token values, immutability, scale progression, and line height invariants
-- [x] `constants/__tests__/theme.test-d.ts` exists with compile-time type tests verifying literal type preservation via `@ts-expect-error`
-- [x] Test structure follows the same describe/it pattern as `colors.test.ts`
+- [x] `constants/metrics.ts` file exists and exports `METRICS: Record<MetricType, MetricDefinition>`
+- [x] METRICS record has exactly 12 entries — one per MetricType
+- [x] Heart Score weights sum to 100 across the 8 scored metrics
+- [x] Trend-only metrics (weight, walking_hr_avg) have `normRanges: null` and `heartScoreWeight: 0`; vo2_max has `normRanges: null` and `heartScoreWeight: 10` (per SPEC §8.2)
+- [x] BP systolic and diastolic both have `bpCompositeGroup: 'blood_pressure'`
+- [x] All normRanges (when not null) have green, yellow, red with `min <= max`
+- [x] Yellow ranges border green ranges (no gaps, no overlaps)
+- [x] File uses `Object.freeze()` for immutability


### PR DESCRIPTION
## Summary
# Issue #30 — Create constants/metrics.ts with all 12 metric definitions

## Status: Complete

Created `constants/metrics.ts` exporting `METRICS: Record<MetricType, MetricDefinition>` with all 12 entries, plus tests.

## Changes

### `constants/metrics.ts`

Exports `METRICS` — a deeply frozen `Record<MetricType, MetricDefinition>` with all 12 metric entries:

| Metric | Category | Weight | Norm Ranges |
|---|---|---|---|
| heart_rate | cardiac-function | 0 | green 60–100, yellow 100–120, red 120–300 bpm |
| resting_heart_rate | cardiac-function | 15 | green 40–80, yellow 80–92, red 92–300 bpm |
| blood_pressure_systolic | risk-markers | 10 | green 90–120, yellow 120–140, red 140–300 mmHg |
| blood_pressure_diastolic | risk-markers | 10 | green 60–80, yellow 80–90, red 90–200 mmHg |
| hrv | cardiac-function | 15 | red 0–15, yellow 15–20, green 20–500 ms |
| blood_glucose | risk-markers | 15 | green 3.9–5.6, yellow 5.6–7.0, red 7.0–30 mmol/L |
| weight | trend-only | 0 | null |
| sleep | lifestyle | 10 | red 0–5, yellow 5–7, green 7–24 hours |
| steps | lifestyle | 8 | red 0–4000, yellow 4000–7000, green 7000–100000 count |
| workouts | lifestyle | 7 | red 0–75, yellow 75–150, green 150–10000 minutes |
| walking_hr_avg | trend-only | 0 | null |
| vo2_max | cardiac-function | 10 | null |

**Heart score weights sum: 100** (0+15+10+10+15+15+0+10+8+7+0+10)

Both `blood_pressure_systolic` and `blood_pressure_diastolic` have `bpCompositeGroup: 'blood_pressure'`. All three trend-only metrics have `normRanges: null`. Yellow ranges are contiguous with green on every metric (no gaps, no overlaps). The outer object and each nested definition/normRange object is `Object.freeze()`d.

### `constants/__tests__/metrics.test.ts`

Jest tests covering all acceptance criteria:
- 12 keys matching all `MetricType` values
- Weights sum to exactly 100
- Non-null normRanges have `min <= max` for all three thresholds
- `weight` and `walking_hr_avg` have `normRanges: null` and `heartScoreWeight: 0`
- `vo2_max` has `normRanges: null`
- Both BP entries have `bpCompositeGroup: 'blood_pressure'`; all others have `undefined`
- Yellow ranges contiguous with green (no gaps/overlaps)
- `METRICS`, each definition, and each normRanges are frozen

## Acceptance Criteria

- [x] `constants/metrics.ts` file exists and exports `METRICS: Record<MetricType, MetricDefinition>`
- [x] METRICS record has exactly 12 entries — one per MetricType
- [x] Heart Score weights sum to 100 across the 8 scored metrics
- [x] Trend-only metrics (weight, walking_hr_avg) have `normRanges: null` and `heartScoreWeight: 0`; vo2_max has `normRanges: null` and `heartScoreWeight: 10` (per SPEC §8.2)
- [x] BP systolic and diastolic both have `bpCompositeGroup: 'blood_pressure'`
- [x] All normRanges (when not null) have green, yellow, red with `min <= max`
- [x] Yellow ranges border green ranges (no gaps, no overlaps)
- [x] File uses `Object.freeze()` for immutability

Closes #30

---
Implemented by AI Teammate (Claude Code)