### PR TITLE
feat: issue #35

### DIFF
--- a/constants/heartScoreRanges.ts
+++ b/constants/heartScoreRanges.ts
@@ -29,3 +29,18 @@ export const HEART_SCORE_CURVES: Partial<Record<MetricType, ScoreBreakpoint[]>> 
     { value: 45, score: 100 },
   ],
 };
+
+/**
+ * VO2 Max simplified linear scoring curve (mL/kg/min → sub-score).
+ *
+ * Spans 20–60 mL/kg/min → 0–100 sub-score.
+ * Age/sex percentile tables are post-MVP; this is a flat age-independent scale.
+ * Breakpoints are sorted ascending by value.
+ */
+export const VO2_MAX_SCORE_CURVE: readonly ScoreBreakpoint[] = [
+  { value: 20, score: 0 },
+  { value: 30, score: 25 },
+  { value: 40, score: 50 },
+  { value: 50, score: 75 },
+  { value: 60, score: 100 },
+] as const;

--- a/input/issue.md
+++ b/input/issue.md
@@ -1,61 +1,48 @@
-title:	Implement calculateHeartScore() service with weight redistribution
+title:	Define HeartScore types and VO2 max scoring constants
 state:	OPEN
 author:	veramey
 labels:	sub-issue, tests-ready
-comments:	0
+comments:	7
 assignees:	
 projects:	azloheart (In progress)
 milestone:	
-number:	36
+number:	35
 --
 Parent: #34
 
 See SPEC.md §5 Heart Score, §3 Data Model
 
-Implement the core `services/heartScore.ts` calculation service. Depends on types and constants from the previous sub-task.
+Create the foundational types and constants needed before implementing the calculation service.
 
-**Pillar weights:** Cardiac Function 40% (resting HR 15%, HRV 15%, VO2 max 10%), Risk Markers 35% (blood pressure 20%, blood glucose 15%), Lifestyle 25% (sleep 10%, steps 8%, workouts 7%).
+**Files to create:**
+- `types/heartScore.ts` — TypeScript types: `HeartScoreInput` (map of metric averages keyed by MetricType), `HeartScoreResult` (score: number | null, pillarScores: PillarBreakdown, perMetricSubScores: Record<MetricType, number>, metricsUsed: number, isInsufficient: boolean), `PillarBreakdown` (cardiac, riskMarkers, lifestyle — each with score and contributingMetrics)
+- `constants/heartScoreRanges.ts` — VO2 max relative scoring curve: simplified linear scale mapping 20–60 mL/kg/min → 0–100 sub-score (age/sex percentile tables are post-MVP)
 
-**Key implementation details:**
-- Generic `normalizeToScore(value, normRange, direction: 'higher' | 'lower')` function — clamps to 0–100, uses norm ranges from `constants/metrics.ts`
-- BP composite: average systolic and diastolic sub-scores into one 20%-weight metric; if only one is present, treat BP as missing
-- VO2 max: use `constants/heartScoreRanges.ts` curve instead of norm-based normalization
-- Weight redistribution: missing metrics give their weight to other metrics in the same pillar proportionally; if an entire pillar is missing, redistribute to remaining pillars proportionally
-- Return `null` score with `isInsufficient: true` when fewer than 2 metrics have data
-- Document in JSDoc that the caller is responsible for passing only 7-day averages excluding readings older than 30 days (stale filtering is NOT done here)
-- Use `heartScoreWeight` field from `constants/metrics.ts` as the single source of truth for weights — do not hardcode weight values
+No logic here — pure type definitions and static data.
 
 ## Acceptance Criteria
-- [ ] `calculateHeartScore(input: HeartScoreInput): HeartScoreResult` exported from `services/heartScore.ts`
-- [ ] Three-pillar weighted calculation matches the weights in SPEC.md §5 (Cardiac 40%, Risk 35%, Lifestyle 25%)
-- [ ] Missing metrics redistribute weight proportionally within the same pillar first, then across pillars
-- [ ] BP treated as missing if either systolic or diastolic is absent
-- [ ] VO2 max scored via relative curve, not norm ranges
-- [ ] Returns `{ score: null, isInsufficient: true }` when fewer than 2 metrics provided
-- [ ] Sub-scores clamped to 0–100 for values outside norm boundaries
-- [ ] Inverted metrics (resting HR, BP) score highest when in healthy range (lower values → higher score)
+- [ ] `HeartScoreInput` accepts all 8 scored metrics (resting_hr, hrv, vo2_max, bp_systolic, bp_diastolic, blood_glucose, sleep, steps, workouts) as optional fields
+- [ ] `HeartScoreResult` includes score, pillar breakdowns, per-metric sub-scores, metricsUsed count, and isInsufficient flag
+- [ ] `constants/heartScoreRanges.ts` exports VO2_MAX_SCORE_CURVE with at least 5 breakpoints spanning 20–60 mL/kg/min
+- [ ] All types are exported and importable by `services/heartScore.ts`
 
 ## Test Cases
 
 ### Happy Path
-- [ ] `calculateHeartScore` returns a score between 0–100 when all 11 metrics are provided with valid 7-day averages
-- [ ] Three-pillar weights are correct: Cardiac Function contributes 40%, Risk Markers 35%, Lifestyle 25% to the total score (verify by providing only one pillar at a time and asserting proportional output)
-- [ ] BP composite score is correctly averaged from systolic and diastolic sub-scores, contributing 20% weight total
+- [ ] `HeartScoreInput` type accepts all 9 scored metrics as optional fields (`resting_hr`, `hrv`, `vo2_max`, `bp_systolic`, `bp_diastolic`, `blood_glucose`, `sleep`, `steps`, `workouts`) — verify TypeScript compiles with a partial object (e.g. only `resting_hr` provided)
+- [ ] `HeartScoreResult` type compiles with all required fields: `score: number | null`, `pillarScores: PillarBreakdown`, `perMetricSubScores`, `metricsUsed: number`, `isInsufficient: boolean`
+- [ ] `VO2_MAX_SCORE_CURVE` exported from `constants/heartScoreRanges.ts` contains at least 5 breakpoints and spans from 20 to 60 mL/kg/min with scores mapping 0–100
 
 ### Edge Cases
-- [ ] Returns `{ score: null, isInsufficient: true }` when only 1 metric is provided
-- [ ] Returns `{ score: null, isInsufficient: true }` when input is empty (`{}`)
-- [ ] Missing metric redistributes its weight proportionally to other metrics in the same pillar (e.g., HRV missing → resting HR and VO2 max absorb its 15% within Cardiac Function)
-- [ ] Entire Cardiac Function pillar missing → its 40% redistributes proportionally to Risk Markers and Lifestyle pillars
-- [ ] BP treated as missing when only systolic is present (diastolic absent), weight redistributed within Risk Markers pillar
-- [ ] Sub-scores clamp to 100 for values far below norms on inverted metrics (e.g., resting HR of 10 bpm → score 100, not above 100)
-- [ ] Sub-scores clamp to 0 for values far above norms on inverted metrics (e.g., resting HR of 300 bpm → score 0)
+- [ ] `HeartScoreInput` with no fields provided (empty object `{}`) satisfies the type — all fields are optional, not required
+- [ ] `VO2_MAX_SCORE_CURVE` boundary values are correct: breakpoint at 20 mL/kg/min maps to sub-score 0 and breakpoint at 60 mL/kg/min maps to sub-score 100
+- [ ] `HeartScoreResult` allows `score: null` (represents insufficient data case) without TypeScript error
 
 ### Mocking Strategy
-- **HealthKit:** Not applicable — `services/heartScore.ts` is a pure calculation function; no HealthKit calls
-- **Constants:** Import real `constants/metrics.ts` and `constants/heartScoreRanges.ts` in tests — do not mock, since the AC requires using `heartScoreWeight` as the single source of truth
-- **Navigation:** Not applicable — service layer only
-- **Storage:** Not applicable — service layer only; caller is responsible for passing pre-filtered 7-day averages
+- HealthKit: not applicable — this sub-issue is pure types and constants, no runtime HealthKit calls
+- Navigation: not applicable — no UI or navigation involved
+- Storage: not applicable — no DB reads/writes involved
+- Test approach: use TypeScript type-checking tests (`tsc --noEmit`) to validate type correctness; use simple Jest unit tests to assert shape and values of the `VO2_MAX_SCORE_CURVE` constant (breakpoint count, min/max values, score range)
 
 ---
 _Test cases generated by QA Agent (Claude Code)_

--- a/output/summary.md
+++ b/output/summary.md
@@ -1,50 +1,26 @@
-# Issue #36 — Implement calculateHeartScore() service
+## Issue #35 — HeartScore Types and VO2 Max Scoring Constants
 
-## Status: Complete
+### What was done
 
-## Changes
+**`types/heartScore.ts`** (new file)
+- `ScoredMetricType` — union of all 9 metrics that contribute to Heart Score
+- `HeartScoreInput` — `Partial<Record<ScoredMetricType, number>>` (all fields optional; non-scored metrics rejected at compile time)
+- `PillarScore` — `{ score: number | null; contributingMetrics: MetricType[] }`
+- `PillarBreakdown` — `{ cardiac, riskMarkers, lifestyle }` each a `PillarScore`
+- `HeartScoreResult` — `{ score, pillarScores, perMetricSubScores, metricsUsed, isInsufficient }`
 
-### `constants/heartScoreRanges.ts` (new)
+**`constants/heartScoreRanges.ts`** (updated)
+- Added `VO2_MAX_SCORE_CURVE` — 5 breakpoints, 20→0 to 60→100 mL/kg/min, linear
+- Kept `HEART_SCORE_CURVES` (used by existing `services/heartScore.ts`) unchanged to preserve existing tests
 
-Exports `HEART_SCORE_CURVES: Partial<Record<MetricType, ScoreBreakpoint[]>>` — piecewise linear scoring curves for metrics that have no `normRanges` in `constants/metrics.ts`. Currently contains the VO2 max curve from SPEC §8.3 (breakpoints at 0/15/25/35/45 mL/kg/min → scores 0/20/50/80/100).
+**`types/__tests__/heartScore.test.ts`** (new file)
+- Jest tests: breakpoint count (≥5), boundary values (20→0, 60→100), range constraints, ascending order, monotone scores
 
-### `services/heartScore.ts` (new)
+**`types/__tests__/heartScore.test-d.ts`** (new file)
+- Compile-time (`tsc --noEmit`) tests: partial/empty `HeartScoreInput`, invalid metric rejection, full `HeartScoreResult`, `score: null` valid, missing required fields flagged with `@ts-expect-error`
 
-Exports:
-- `HeartScoreInput` — `Partial<Record<MetricType, number>>` (7-day averages, caller pre-filters for staleness)
-- `HeartScoreResult` — `{ score: number | null; isInsufficient: boolean }`
-- `normalizeToScore(value, normRange, direction)` — generic 0–100 normalizer using `normRanges` from `constants/metrics.ts`; clamps values outside the range
-- `calculateHeartScore(input)` — main exported function
-
-**Algorithm:**
-1. BP composite: requires both systolic AND diastolic; score = `(sys_score + dia_score) / 2`, combined weight = 20. If either is absent, the composite is excluded.
-2. All other metrics: scored via `normalizeToScore` (norm-based) or `interpolateCurve` (VO2 max curve).
-3. Insufficient data: fewer than 2 logical metrics → `{ score: null, isInsufficient: true }`.
-4. Pillar scores: `Σ(metric_score × metric_weight) / Σ(available weights)` — missing metrics naturally redistribute within the pillar.
-5. Final score: `Σ(pillar_score × pillar_total_weight) / Σ(available pillar total weights)` — missing pillars redistribute to remaining pillars.
-6. All weights sourced from `METRICS[...].heartScoreWeight` (no hardcoded values).
-
-### `services/__tests__/heartScore.test.ts` (new)
-
-Jest tests covering all acceptance criteria:
-
-| Category | Tests |
-|---|---|
-| Happy path | All metrics → score 0–100; all perfect → score 100 |
-| Pillar weights | Cardiac 40%, Risk 35%, Lifestyle 25% (verified by making other pillars score 0) |
-| BP composite | Average of sub-scores verified mathematically |
-| Insufficient data | 0 metrics, 1 metric, BP-only (counts as 1), trend-only-only |
-| Weight redistribution | HRV missing (same pillar); entire cardiac pillar missing; BP incomplete (only systolic) |
-| Score clamping | resting HR 10 bpm → 100 (not above); resting HR 300 bpm → 0 (not below) |
-| normalizeToScore | Green/yellow/red zone interpolation and boundary clamping for both directions |
-
-## Acceptance Criteria
-
-- [x] `calculateHeartScore(input: HeartScoreInput): HeartScoreResult` exported from `services/heartScore.ts`
-- [x] Three-pillar weighted calculation matches SPEC §5 (Cardiac 40%, Risk 35%, Lifestyle 25%)
-- [x] Missing metrics redistribute weight proportionally within pillar first, then across pillars
-- [x] BP treated as missing if either systolic or diastolic is absent
-- [x] VO2 max scored via `HEART_SCORE_CURVES` relative curve, not norm ranges
-- [x] Returns `{ score: null, isInsufficient: true }` when fewer than 2 metrics provided
-- [x] Sub-scores clamped to 0–100 for values outside norm boundaries
-- [x] Inverted metrics (resting HR, BP) score 100 at low values, 0 at high values
+### Acceptance criteria
+- [x] `HeartScoreInput` accepts all 9 scored metrics as optional
+- [x] `HeartScoreResult` includes score, pillar breakdowns, per-metric sub-scores, metricsUsed, isInsufficient
+- [x] `VO2_MAX_SCORE_CURVE` has 5 breakpoints spanning 20–60 mL/kg/min → 0–100
+- [x] All types exported and importable by `services/heartScore.ts`

--- a/types/__tests__/heartScore.test-d.ts
+++ b/types/__tests__/heartScore.test-d.ts
@@ -1,0 +1,123 @@
+/**
+ * Compile-time type tests — verified by `tsc --noEmit`.
+ * Asserts type correctness for HeartScoreInput, HeartScoreResult, and PillarBreakdown.
+ */
+import type {
+  HeartScoreInput,
+  HeartScoreResult,
+  PillarBreakdown,
+  PillarScore,
+  ScoredMetricType,
+} from '../heartScore';
+
+// ── HeartScoreInput: all scored metrics are optional ─────────────────────────
+
+// Partial object with only resting_hr satisfies the type.
+const _partialInput: HeartScoreInput = {
+  resting_heart_rate: 65,
+};
+
+// Empty object satisfies the type — all fields are optional.
+const _emptyInput: HeartScoreInput = {};
+
+// All 9 scored metrics together satisfy the type.
+const _fullInput: HeartScoreInput = {
+  resting_heart_rate: 65,
+  hrv: 45,
+  vo2_max: 38,
+  blood_pressure_systolic: 118,
+  blood_pressure_diastolic: 76,
+  blood_glucose: 5.2,
+  sleep: 7.5,
+  steps: 8500,
+  workouts: 180,
+};
+
+// Non-scored metrics are NOT assignable to HeartScoreInput.
+// @ts-expect-error — 'heart_rate' is not a ScoredMetricType
+const _invalidMetric: HeartScoreInput = { heart_rate: 72 };
+
+// @ts-expect-error — 'weight' is not a ScoredMetricType
+const _weightNotScored: HeartScoreInput = { weight: 75 };
+
+// ── ScoredMetricType includes all 9 scored metrics ───────────────────────────
+type _RestingHR   = ScoredMetricType & 'resting_heart_rate';
+type _HRV         = ScoredMetricType & 'hrv';
+type _VO2Max      = ScoredMetricType & 'vo2_max';
+type _BPSystolic  = ScoredMetricType & 'blood_pressure_systolic';
+type _BPDiastolic = ScoredMetricType & 'blood_pressure_diastolic';
+type _Glucose     = ScoredMetricType & 'blood_glucose';
+type _Sleep       = ScoredMetricType & 'sleep';
+type _Steps       = ScoredMetricType & 'steps';
+type _Workouts    = ScoredMetricType & 'workouts';
+
+// ── PillarScore shape ─────────────────────────────────────────────────────────
+const _pillarScore: PillarScore = {
+  score: 78,
+  contributingMetrics: ['resting_heart_rate', 'hrv'],
+};
+
+// score: null is valid (no metrics contributed)
+const _pillarScoreNull: PillarScore = {
+  score: null,
+  contributingMetrics: [],
+};
+
+// ── PillarBreakdown shape ─────────────────────────────────────────────────────
+const _pillarBreakdown: PillarBreakdown = {
+  cardiac: { score: 85, contributingMetrics: ['resting_heart_rate', 'hrv', 'vo2_max'] },
+  riskMarkers: { score: 72, contributingMetrics: ['blood_pressure_systolic', 'blood_pressure_diastolic'] },
+  lifestyle: { score: 90, contributingMetrics: ['sleep', 'steps', 'workouts'] },
+};
+
+// ── HeartScoreResult: all required fields present ─────────────────────────────
+const _fullResult: HeartScoreResult = {
+  score: 82,
+  pillarScores: _pillarBreakdown,
+  perMetricSubScores: {
+    resting_heart_rate: 90,
+    hrv: 80,
+    sleep: 95,
+  },
+  metricsUsed: 3,
+  isInsufficient: false,
+};
+
+// score: null is valid (insufficient data)
+const _insufficientResult: HeartScoreResult = {
+  score: null,
+  pillarScores: {
+    cardiac: { score: null, contributingMetrics: [] },
+    riskMarkers: { score: null, contributingMetrics: [] },
+    lifestyle: { score: null, contributingMetrics: [] },
+  },
+  perMetricSubScores: {},
+  metricsUsed: 0,
+  isInsufficient: true,
+};
+
+// @ts-expect-error — score field is required
+const _missingScore: HeartScoreResult = {
+  pillarScores: _pillarBreakdown,
+  perMetricSubScores: {},
+  metricsUsed: 0,
+  isInsufficient: true,
+};
+
+// @ts-expect-error — pillarScores field is required
+const _missingPillarScores: HeartScoreResult = {
+  score: null,
+  perMetricSubScores: {},
+  metricsUsed: 0,
+  isInsufficient: true,
+};
+
+// @ts-expect-error — isInsufficient field is required
+const _missingIsInsufficient: HeartScoreResult = {
+  score: 50,
+  pillarScores: _pillarBreakdown,
+  perMetricSubScores: {},
+  metricsUsed: 3,
+};
+
+export {};

--- a/types/__tests__/heartScore.test.ts
+++ b/types/__tests__/heartScore.test.ts
@@ -1,0 +1,45 @@
+import { VO2_MAX_SCORE_CURVE } from '../../constants/heartScoreRanges';
+
+describe('VO2_MAX_SCORE_CURVE', () => {
+  it('has at least 5 breakpoints', () => {
+    expect(VO2_MAX_SCORE_CURVE.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('first breakpoint value is 20 mL/kg/min with score 0', () => {
+    const first = VO2_MAX_SCORE_CURVE[0];
+    expect(first.value).toBe(20);
+    expect(first.score).toBe(0);
+  });
+
+  it('last breakpoint value is 60 mL/kg/min with score 100', () => {
+    const last = VO2_MAX_SCORE_CURVE[VO2_MAX_SCORE_CURVE.length - 1];
+    expect(last.value).toBe(60);
+    expect(last.score).toBe(100);
+  });
+
+  it('all breakpoint values are within [20, 60]', () => {
+    for (const bp of VO2_MAX_SCORE_CURVE) {
+      expect(bp.value).toBeGreaterThanOrEqual(20);
+      expect(bp.value).toBeLessThanOrEqual(60);
+    }
+  });
+
+  it('all breakpoint scores are within [0, 100]', () => {
+    for (const bp of VO2_MAX_SCORE_CURVE) {
+      expect(bp.score).toBeGreaterThanOrEqual(0);
+      expect(bp.score).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it('breakpoints are sorted ascending by value', () => {
+    for (let i = 1; i < VO2_MAX_SCORE_CURVE.length; i++) {
+      expect(VO2_MAX_SCORE_CURVE[i].value).toBeGreaterThan(VO2_MAX_SCORE_CURVE[i - 1].value);
+    }
+  });
+
+  it('scores are non-decreasing (higher VO2 max → higher or equal score)', () => {
+    for (let i = 1; i < VO2_MAX_SCORE_CURVE.length; i++) {
+      expect(VO2_MAX_SCORE_CURVE[i].score).toBeGreaterThanOrEqual(VO2_MAX_SCORE_CURVE[i - 1].score);
+    }
+  });
+});

--- a/types/heartScore.ts
+++ b/types/heartScore.ts
@@ -1,0 +1,48 @@
+import type { MetricType } from './health';
+
+/** The 9 MetricType values that contribute to the Heart Score calculation. */
+export type ScoredMetricType =
+  | 'resting_heart_rate'
+  | 'hrv'
+  | 'vo2_max'
+  | 'blood_pressure_systolic'
+  | 'blood_pressure_diastolic'
+  | 'blood_glucose'
+  | 'sleep'
+  | 'steps'
+  | 'workouts';
+
+/**
+ * 7-day averages for any subset of scored metrics.
+ * All fields are optional — caller provides only what is available.
+ */
+export type HeartScoreInput = Partial<Record<ScoredMetricType, number>>;
+
+/** Score and contributing metrics for a single Heart Score pillar. */
+export interface PillarScore {
+  /** Weighted pillar sub-score in [0, 100], or null when no metrics contributed. */
+  score: number | null;
+  /** Metrics from this pillar that were present in the input. */
+  contributingMetrics: MetricType[];
+}
+
+/** Per-pillar breakdown of the Heart Score calculation. */
+export interface PillarBreakdown {
+  cardiac: PillarScore;
+  riskMarkers: PillarScore;
+  lifestyle: PillarScore;
+}
+
+/** Full result returned by the Heart Score calculation service. */
+export interface HeartScoreResult {
+  /** Composite score in [0, 100], or null when data is insufficient. */
+  score: number | null;
+  /** Per-pillar breakdown of contributing metrics and pillar-level scores. */
+  pillarScores: PillarBreakdown;
+  /** Individual sub-score (0–100) for each metric that was scored. */
+  perMetricSubScores: Partial<Record<ScoredMetricType, number>>;
+  /** Number of logical metrics used (BP systolic+diastolic count as 1). */
+  metricsUsed: number;
+  /** True when fewer than 2 metrics were available — score will be null. */
+  isInsufficient: boolean;
+}


### PR DESCRIPTION
## Summary
## Issue #35 — HeartScore Types and VO2 Max Scoring Constants

### What was done

**`types/heartScore.ts`** (new file)
- `ScoredMetricType` — union of all 9 metrics that contribute to Heart Score
- `HeartScoreInput` — `Partial<Record<ScoredMetricType, number>>` (all fields optional; non-scored metrics rejected at compile time)
- `PillarScore` — `{ score: number | null; contributingMetrics: MetricType[] }`
- `PillarBreakdown` — `{ cardiac, riskMarkers, lifestyle }` each a `PillarScore`
- `HeartScoreResult` — `{ score, pillarScores, perMetricSubScores, metricsUsed, isInsufficient }`

**`constants/heartScoreRanges.ts`** (updated)
- Added `VO2_MAX_SCORE_CURVE` — 5 breakpoints, 20→0 to 60→100 mL/kg/min, linear
- Kept `HEART_SCORE_CURVES` (used by existing `services/heartScore.ts`) unchanged to preserve existing tests

**`types/__tests__/heartScore.test.ts`** (new file)
- Jest tests: breakpoint count (≥5), boundary values (20→0, 60→100), range constraints, ascending order, monotone scores

**`types/__tests__/heartScore.test-d.ts`** (new file)
- Compile-time (`tsc --noEmit`) tests: partial/empty `HeartScoreInput`, invalid metric rejection, full `HeartScoreResult`, `score: null` valid, missing required fields flagged with `@ts-expect-error`

### Acceptance criteria
- [x] `HeartScoreInput` accepts all 9 scored metrics as optional
- [x] `HeartScoreResult` includes score, pillar breakdowns, per-metric sub-scores, metricsUsed, isInsufficient
- [x] `VO2_MAX_SCORE_CURVE` has 5 breakpoints spanning 20–60 mL/kg/min → 0–100
- [x] All types exported and importable by `services/heartScore.ts`

Closes #35

---
Implemented by AI Teammate (Claude Code)